### PR TITLE
Center the items over time graph

### DIFF
--- a/web/src/components/ItemsOverTimeCell/ItemsOverTimeCell.tsx
+++ b/web/src/components/ItemsOverTimeCell/ItemsOverTimeCell.tsx
@@ -82,7 +82,7 @@ export const Success = ({
       <CardHeader>
         <CardTitle>Datasets Over Time</CardTitle>
       </CardHeader>
-      <CardContent>
+      <CardContent className="flex justify-center">
         <BarChart width={400} height={500} data={datesWithLicenses}>
           <Tooltip />
           <CartesianGrid vertical={false} strokeDasharray={5} />


### PR DESCRIPTION
This PR centers the items over time graph.



<img width="536" alt="image" src="https://github.com/nsunami/tue-rdm-dashboard-rw/assets/17035406/85fe1585-7091-45d6-afaa-c7dfdf2920d5">
