### PR TITLE
Update Redwood JS to 7.6.3

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redwoodjs/api": "7.6.2",
-    "@redwoodjs/graphql-server": "7.6.2"
+    "@redwoodjs/api": "7.6.3",
+    "@redwoodjs/graphql-server": "7.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "7.6.2",
-    "@redwoodjs/project-config": "7.6.2",
+    "@redwoodjs/core": "7.6.3",
+    "@redwoodjs/project-config": "7.6.3",
     "prettier-plugin-tailwindcss": "0.4.1"
   },
   "eslintConfig": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,9 +15,9 @@
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-slot": "^1.0.2",
-    "@redwoodjs/forms": "7.6.2",
-    "@redwoodjs/router": "7.6.2",
-    "@redwoodjs/web": "7.6.2",
+    "@redwoodjs/forms": "7.6.3",
+    "@redwoodjs/router": "7.6.3",
+    "@redwoodjs/web": "7.6.3",
     "@tremor/react": "^3.17.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -29,7 +29,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "@redwoodjs/vite": "7.6.2",
+    "@redwoodjs/vite": "7.6.3",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,16 +1703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
-  version: 7.24.5
-  resolution: "@babel/runtime@npm:7.24.5"
-  dependencies:
-    regenerator-runtime: "npm:^0.14.0"
-  checksum: 10c0/05730e43e8ba6550eae9fd4fb5e7d9d3cb91140379425abcb2a1ff9cebad518a280d82c4c4b0f57ada26a863106ac54a748d90c775790c0e2cd0ddd85ccdf346
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.24.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.24.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.24.6
   resolution: "@babel/runtime@npm:7.24.6"
   dependencies:
@@ -5023,15 +5014,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redwoodjs/api-server@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/api-server@npm:7.6.2"
+"@redwoodjs/api-server@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/api-server@npm:7.6.3"
   dependencies:
     "@fastify/url-data": "npm:5.4.0"
-    "@redwoodjs/context": "npm:7.6.2"
-    "@redwoodjs/fastify-web": "npm:7.6.2"
-    "@redwoodjs/project-config": "npm:7.6.2"
-    "@redwoodjs/web-server": "npm:7.6.2"
+    "@redwoodjs/context": "npm:7.6.3"
+    "@redwoodjs/fastify-web": "npm:7.6.3"
+    "@redwoodjs/project-config": "npm:7.6.3"
+    "@redwoodjs/web-server": "npm:7.6.3"
     chalk: "npm:4.1.2"
     chokidar: "npm:3.6.0"
     dotenv-defaults: "npm:5.0.2"
@@ -5046,7 +5037,7 @@ __metadata:
     split2: "npm:4.2.0"
     yargs: "npm:17.7.2"
   peerDependencies:
-    "@redwoodjs/graphql-server": 7.6.2
+    "@redwoodjs/graphql-server": 7.6.3
   peerDependenciesMeta:
     "@redwoodjs/graphql-server":
       optional: true
@@ -5054,13 +5045,13 @@ __metadata:
     rw-api-server-watch: dist/watch.js
     rw-log-formatter: dist/logFormatter/bin.js
     rw-server: dist/bin.js
-  checksum: 10c0/4cbfff69ceebdf7104af622c82fa23d858303f3d7f3a8d2b0364c8fa490ab48848c4a19a75215ba94854bcd43551bef9d7ded5151bf486cf204efa7bd575c272
+  checksum: 10c0/9c1e91bed511818421776812bf8f3fe167c38d9560cbca219e8a68e8d56474d1e96f181e77dc5cd99c8103bfa286058e52b2de5225c2652ff8919e5eca2c0751
   languageName: node
   linkType: hard
 
-"@redwoodjs/api@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/api@npm:7.6.2"
+"@redwoodjs/api@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/api@npm:7.6.3"
   dependencies:
     "@babel/runtime-corejs3": "npm:7.24.5"
     "@prisma/client": "npm:5.14.0"
@@ -5084,23 +5075,23 @@ __metadata:
     rw: dist/bins/redwood.js
     rwfw: dist/bins/rwfw.js
     tsc: dist/bins/tsc.js
-  checksum: 10c0/85bef86cae4bf9878e0d8673c2a1c60f7dbc45576648dbc674abf4cfa400e64e03995a7a089b2a9014ed56bdb73498d534985321cfc4b9ee9dba6d10b2e24f00
+  checksum: 10c0/2cedd8691a8cff170d9adcc90d99da2b3af503aba7db3510c132894f8a3abce3e76602b1e72cad35c0026f2e485074f56a39a90f78d12445cdd440b011ef2c72
   languageName: node
   linkType: hard
 
-"@redwoodjs/auth@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/auth@npm:7.6.2"
+"@redwoodjs/auth@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/auth@npm:7.6.3"
   dependencies:
     core-js: "npm:3.37.1"
     react: "npm:18.2.0"
-  checksum: 10c0/fbbab1e72a8522e7daf730de49b3465163c868b8bec5a66614ba2bbecf7e7ad0a2b254ad4173beb36fbad735e49ec28587b549dad759af10a370421b4a87e035
+  checksum: 10c0/9ecb784e5122f3692a52a2b69b45fa4f88b326ab9df734a0148de68c833c0ccfd03bbf2e9a9b2a75e4cb369cc72fe147e9f1f9f43490d33821f46f67a46df5ae
   languageName: node
   linkType: hard
 
-"@redwoodjs/babel-config@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/babel-config@npm:7.6.2"
+"@redwoodjs/babel-config@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/babel-config@npm:7.6.3"
   dependencies:
     "@babel/core": "npm:^7.22.20"
     "@babel/parser": "npm:^7.22.16"
@@ -5115,7 +5106,7 @@ __metadata:
     "@babel/register": "npm:^7.22.15"
     "@babel/runtime-corejs3": "npm:7.24.5"
     "@babel/traverse": "npm:^7.22.20"
-    "@redwoodjs/project-config": "npm:7.6.2"
+    "@redwoodjs/project-config": "npm:7.6.3"
     babel-plugin-auto-import: "npm:1.1.0"
     babel-plugin-graphql-tag: "npm:3.3.0"
     babel-plugin-module-resolver: "npm:5.0.2"
@@ -5123,19 +5114,19 @@ __metadata:
     fast-glob: "npm:3.3.2"
     graphql: "npm:16.8.1"
     typescript: "npm:5.4.5"
-  checksum: 10c0/5f94555083689d10696d58c4bc5d64253e906d89ecc567e450c1c91381e098918a768c4a92e0e5ce4ff98ea9b2434bd6474c176b94c000ba20b1e6f40b216cb1
+  checksum: 10c0/fc95b8b75f9e8cfb8bbdc28c76240350c14b88d9f8d3e7b9e01706cc8d18492255de33f0499529aa4db610489280eb1f9843d892efd909f874522d9682b6e87a
   languageName: node
   linkType: hard
 
-"@redwoodjs/cli-helpers@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/cli-helpers@npm:7.6.2"
+"@redwoodjs/cli-helpers@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/cli-helpers@npm:7.6.3"
   dependencies:
     "@babel/core": "npm:^7.22.20"
     "@iarna/toml": "npm:2.2.5"
     "@opentelemetry/api": "npm:1.8.0"
-    "@redwoodjs/project-config": "npm:7.6.2"
-    "@redwoodjs/telemetry": "npm:7.6.2"
+    "@redwoodjs/project-config": "npm:7.6.3"
+    "@redwoodjs/telemetry": "npm:7.6.3"
     chalk: "npm:4.1.2"
     dotenv: "npm:16.4.5"
     execa: "npm:5.1.1"
@@ -5145,13 +5136,13 @@ __metadata:
     prettier: "npm:2.8.8"
     prompts: "npm:2.4.2"
     terminal-link: "npm:2.1.1"
-  checksum: 10c0/3a8d29c2a612e42e4dfa2045918fd689488c11c54901e4a604603977330bc7e5158252415cc8fc7715502ff088433549e66d58cd09746b33b03cbca53f164dd8
+  checksum: 10c0/2e5098ad365006647a3dd5f4eceb40d667df0a5f8193f4b1599793feec181a3d1a39c306f52975171f3dcdfafe79c40e6b4ae2f5f215be311134198be70acd06
   languageName: node
   linkType: hard
 
-"@redwoodjs/cli@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/cli@npm:7.6.2"
+"@redwoodjs/cli@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/cli@npm:7.6.3"
   dependencies:
     "@babel/runtime-corejs3": "npm:7.24.5"
     "@iarna/toml": "npm:2.2.5"
@@ -5162,15 +5153,15 @@ __metadata:
     "@opentelemetry/sdk-trace-node": "npm:1.22.0"
     "@opentelemetry/semantic-conventions": "npm:1.22.0"
     "@prisma/internals": "npm:5.14.0"
-    "@redwoodjs/api-server": "npm:7.6.2"
-    "@redwoodjs/cli-helpers": "npm:7.6.2"
-    "@redwoodjs/fastify-web": "npm:7.6.2"
-    "@redwoodjs/internal": "npm:7.6.2"
-    "@redwoodjs/prerender": "npm:7.6.2"
-    "@redwoodjs/project-config": "npm:7.6.2"
-    "@redwoodjs/structure": "npm:7.6.2"
-    "@redwoodjs/telemetry": "npm:7.6.2"
-    "@redwoodjs/web-server": "npm:7.6.2"
+    "@redwoodjs/api-server": "npm:7.6.3"
+    "@redwoodjs/cli-helpers": "npm:7.6.3"
+    "@redwoodjs/fastify-web": "npm:7.6.3"
+    "@redwoodjs/internal": "npm:7.6.3"
+    "@redwoodjs/prerender": "npm:7.6.3"
+    "@redwoodjs/project-config": "npm:7.6.3"
+    "@redwoodjs/structure": "npm:7.6.3"
+    "@redwoodjs/telemetry": "npm:7.6.3"
+    "@redwoodjs/web-server": "npm:7.6.3"
     archiver: "npm:7.0.1"
     boxen: "npm:5.1.2"
     camelcase: "npm:6.3.0"
@@ -5211,30 +5202,30 @@ __metadata:
     redwood: dist/index.js
     rw: dist/index.js
     rwfw: dist/rwfw.js
-  checksum: 10c0/d889d099b18754720f6585ea3eaa25bddda6512aca167e3d6f842d90d8f1e9d5aa6c9da0ce4f48a62b1e78b0279b82e68e360d72265c2bb025ed2437f439b2d9
+  checksum: 10c0/b09cb8824d8a63bdc811519dbd5bc4b9edaa410f3b60b73cb21d5dee541d6d1fedef68fd09e02acb3765ff26a1dc6e8994a994bf1dc3e66bb9d7978251b07905
   languageName: node
   linkType: hard
 
-"@redwoodjs/context@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/context@npm:7.6.2"
-  checksum: 10c0/9996e6b38023742bcf0f3dad80c438a5f3a2ef58b4eda957c3711d784b72b3604611acd95f5a66f2469be6fdfe3d1cf639d643df0f16cd7bf0e294550ff9e30f
+"@redwoodjs/context@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/context@npm:7.6.3"
+  checksum: 10c0/7f276e39954455d1257c6c482dc74834eef6fd3bd848cacb24b630af330313508b239f8a988cc56832d5188ea2e2cebd7e60469dffaa50d07ef7cb39c97e024e
   languageName: node
   linkType: hard
 
-"@redwoodjs/core@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/core@npm:7.6.2"
+"@redwoodjs/core@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/core@npm:7.6.3"
   dependencies:
     "@babel/cli": "npm:7.24.5"
     "@babel/runtime-corejs3": "npm:7.24.5"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:0.5.13"
-    "@redwoodjs/cli": "npm:7.6.2"
-    "@redwoodjs/eslint-config": "npm:7.6.2"
-    "@redwoodjs/internal": "npm:7.6.2"
-    "@redwoodjs/project-config": "npm:7.6.2"
-    "@redwoodjs/testing": "npm:7.6.2"
-    "@redwoodjs/web-server": "npm:7.6.2"
+    "@redwoodjs/cli": "npm:7.6.3"
+    "@redwoodjs/eslint-config": "npm:7.6.3"
+    "@redwoodjs/internal": "npm:7.6.3"
+    "@redwoodjs/project-config": "npm:7.6.3"
+    "@redwoodjs/testing": "npm:7.6.3"
+    "@redwoodjs/web-server": "npm:7.6.3"
     babel-loader: "npm:^9.1.3"
     babel-timing: "npm:0.9.1"
     copy-webpack-plugin: "npm:11.0.0"
@@ -5274,20 +5265,20 @@ __metadata:
     rw-log-formatter: dist/bins/rw-log-formatter.js
     rw-web-server: dist/bins/rw-web-server.js
     rwfw: dist/bins/rwfw.js
-  checksum: 10c0/e9afe3a7aaf1e7c08bf08977c2f5e105bb430242e7f155d3cc9bba43c82a1fb02a193c6d1ee0592b3be79fb1369164e0c7569807412511f273a7750c30a9e169
+  checksum: 10c0/ef8f7705703cbe60c52904c36d854b6026eb4f3485f34a593af81a3372e79547fe85caf5619d4bd2e50ccabef523455af2bc6254d37372d99af4f59a2a578660
   languageName: node
   linkType: hard
 
-"@redwoodjs/eslint-config@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/eslint-config@npm:7.6.2"
+"@redwoodjs/eslint-config@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/eslint-config@npm:7.6.3"
   dependencies:
     "@babel/core": "npm:^7.22.20"
     "@babel/eslint-parser": "npm:7.24.5"
     "@babel/eslint-plugin": "npm:7.24.5"
-    "@redwoodjs/eslint-plugin": "npm:7.6.2"
-    "@redwoodjs/internal": "npm:7.6.2"
-    "@redwoodjs/project-config": "npm:7.6.2"
+    "@redwoodjs/eslint-plugin": "npm:7.6.3"
+    "@redwoodjs/internal": "npm:7.6.3"
+    "@redwoodjs/project-config": "npm:7.6.3"
     "@typescript-eslint/eslint-plugin": "npm:5.62.0"
     "@typescript-eslint/parser": "npm:5.62.0"
     eslint: "npm:8.57.0"
@@ -5301,36 +5292,36 @@ __metadata:
     eslint-plugin-react: "npm:7.34.1"
     eslint-plugin-react-hooks: "npm:4.6.0"
     prettier: "npm:2.8.8"
-  checksum: 10c0/b4383f88cb84392c98044a66d236430d2c76b8db10b243396bdbc225bb8531823fa5f54af70068c4f86d6cf5fb91296d2c3b34ba11699edda8ba911b8cde9e96
+  checksum: 10c0/7878c5797785d4db9578e56134f84127f13b648adf324bf675371512ad92a973cbea3ec10ea6389230231c3491d10dac18a06f1aa835e025702dc55b40876197
   languageName: node
   linkType: hard
 
-"@redwoodjs/eslint-plugin@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/eslint-plugin@npm:7.6.2"
+"@redwoodjs/eslint-plugin@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/eslint-plugin@npm:7.6.3"
   dependencies:
     "@typescript-eslint/utils": "npm:5.62.0"
     eslint: "npm:8.57.0"
-  checksum: 10c0/6903653549f910c0649754dd86334f4e798b19f7c7e1204f2b0160220b3c4914f03e576cdeabcb55299cbb41c2f03c18d50bebb8b89ca3f9db9c491428ea043b
+  checksum: 10c0/f3d7cbec2f09cd98b4df2818e52bd3e336d05f5e416cc6c1f4983f9842888a2595614c8b876bc59b84eb1433620acc8d67489a64862651b3831e516717c5f4d0
   languageName: node
   linkType: hard
 
-"@redwoodjs/fastify-web@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/fastify-web@npm:7.6.2"
+"@redwoodjs/fastify-web@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/fastify-web@npm:7.6.3"
   dependencies:
     "@fastify/http-proxy": "npm:9.5.0"
     "@fastify/static": "npm:6.12.0"
     "@fastify/url-data": "npm:5.4.0"
-    "@redwoodjs/project-config": "npm:7.6.2"
+    "@redwoodjs/project-config": "npm:7.6.3"
     fast-glob: "npm:3.3.2"
-  checksum: 10c0/5940787e271d02d64f3396e814d245286ba605e47b2a2ac2213ef5d5cd20fcc37f06eac526f81d537613083603d5ecb21956c2325249b2101083186c5f395d9c
+  checksum: 10c0/30b868cf0721753e4481b428e5e4df1aea1c9573845cf7c54fe1b013997e353c9b2437e363ee8a8fac024c1eb3c5ad41972eb888dc69bff70e6bdfd6e28f2c37
   languageName: node
   linkType: hard
 
-"@redwoodjs/forms@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/forms@npm:7.6.2"
+"@redwoodjs/forms@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/forms@npm:7.6.3"
   dependencies:
     "@babel/runtime-corejs3": "npm:7.24.5"
     core-js: "npm:3.37.1"
@@ -5339,13 +5330,13 @@ __metadata:
     react-hook-form: "npm:7.51.4"
   peerDependencies:
     react: 18.2.0
-  checksum: 10c0/1209ed0f2cdf7e7328776319c36b3d191145060dd5bac73d837eca73689db3167137d0ff7fd1ddce3e42a73e8cf14f861ff775d5106eb0c46373397198b01239
+  checksum: 10c0/17d595e2cba6d1adb0ce01311457fa94f73daeacb38c4b6f0a292932dbbbd040d838a06039be95b7b60421c82e10e4e268f3ba72d0d7bbe001d40c26b9c278d1
   languageName: node
   linkType: hard
 
-"@redwoodjs/graphql-server@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/graphql-server@npm:7.6.2"
+"@redwoodjs/graphql-server@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/graphql-server@npm:7.6.3"
   dependencies:
     "@babel/runtime-corejs3": "npm:7.24.5"
     "@envelop/core": "npm:5.0.1"
@@ -5359,8 +5350,8 @@ __metadata:
     "@graphql-tools/utils": "npm:10.2.0"
     "@graphql-yoga/plugin-persisted-operations": "npm:3.3.1"
     "@opentelemetry/api": "npm:1.8.0"
-    "@redwoodjs/api": "npm:7.6.2"
-    "@redwoodjs/context": "npm:7.6.2"
+    "@redwoodjs/api": "npm:7.6.3"
+    "@redwoodjs/context": "npm:7.6.3"
     core-js: "npm:3.37.1"
     graphql: "npm:16.8.1"
     graphql-scalars: "npm:1.23.0"
@@ -5368,13 +5359,13 @@ __metadata:
     graphql-yoga: "npm:5.3.1"
     lodash: "npm:4.17.21"
     uuid: "npm:9.0.1"
-  checksum: 10c0/6a788d3716653288f309b5411fae2c174ab85099d95a178f33c33cf0c176da25583d0041e6dc6033dfa3ba78b9f1e8a6bf72a37a46f3d147d7b9647a76c9981f
+  checksum: 10c0/588ca3c040c449c984834dab72ac30445ee8082bf0a61d1547bac2a3465e3f5378216fb5f5ddb893b6cf51759ea1be799b9579361f4412f793bf4948f67c9468
   languageName: node
   linkType: hard
 
-"@redwoodjs/internal@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/internal@npm:7.6.2"
+"@redwoodjs/internal@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/internal@npm:7.6.3"
   dependencies:
     "@babel/core": "npm:^7.22.20"
     "@babel/parser": "npm:^7.22.16"
@@ -5394,10 +5385,10 @@ __metadata:
     "@graphql-codegen/typescript-react-apollo": "npm:3.3.7"
     "@graphql-codegen/typescript-resolvers": "npm:3.2.1"
     "@graphql-tools/documents": "npm:1.0.0"
-    "@redwoodjs/babel-config": "npm:7.6.2"
-    "@redwoodjs/graphql-server": "npm:7.6.2"
-    "@redwoodjs/project-config": "npm:7.6.2"
-    "@redwoodjs/router": "npm:7.6.2"
+    "@redwoodjs/babel-config": "npm:7.6.3"
+    "@redwoodjs/graphql-server": "npm:7.6.3"
+    "@redwoodjs/project-config": "npm:7.6.3"
+    "@redwoodjs/router": "npm:7.6.3"
     "@sdl-codegen/node": "npm:0.0.15"
     chalk: "npm:4.1.2"
     core-js: "npm:3.37.1"
@@ -5418,19 +5409,19 @@ __metadata:
   bin:
     rw-gen: dist/generate/generate.js
     rw-gen-watch: dist/generate/watch.js
-  checksum: 10c0/e28442f02dd6b640580a4ac97b228c3008c9bc768f1a1349fa6fa2d4db52fd937f04068ee27395762b48799c5b7fb148e3be09fc9cf4fad862454b15c0a3a3be
+  checksum: 10c0/e9305312de080eccf4b5168557e7edac0ce19b4883f566de7642c089ad1868a12e86deca5c1266c30487692e56d2cf0a9bc83728e612fd8bee6814891d6feccd
   languageName: node
   linkType: hard
 
-"@redwoodjs/prerender@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/prerender@npm:7.6.2"
+"@redwoodjs/prerender@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/prerender@npm:7.6.3"
   dependencies:
     "@babel/runtime-corejs3": "npm:7.24.5"
-    "@redwoodjs/project-config": "npm:7.6.2"
-    "@redwoodjs/router": "npm:7.6.2"
-    "@redwoodjs/structure": "npm:7.6.2"
-    "@redwoodjs/web": "npm:7.6.2"
+    "@redwoodjs/project-config": "npm:7.6.3"
+    "@redwoodjs/router": "npm:7.6.3"
+    "@redwoodjs/structure": "npm:7.6.3"
+    "@redwoodjs/web": "npm:7.6.3"
     "@whatwg-node/fetch": "npm:0.9.17"
     babel-plugin-ignore-html-and-css-imports: "npm:0.1.0"
     cheerio: "npm:1.0.0-rc.12"
@@ -5440,44 +5431,44 @@ __metadata:
   peerDependencies:
     react: 18.2.0
     react-dom: 18.2.0
-  checksum: 10c0/37ee9c2fb40e1d3f3c505bb09bfd19dfcb0647511c17aca352f8eb0e9df5d066a4342cc78337f189ec5c33d54c1d349bfd8e205f2e24f8c45dd2ba143b5a572a
+  checksum: 10c0/d102601698dc316806f13e742f362d6e58acf1419108dd23d07eee216e1b0d2a4d18938d21575cf8978161353562fe2f4ccd3d0eb473b18de110992d176e4ece
   languageName: node
   linkType: hard
 
-"@redwoodjs/project-config@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/project-config@npm:7.6.2"
+"@redwoodjs/project-config@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/project-config@npm:7.6.3"
   dependencies:
     "@iarna/toml": "npm:2.2.5"
     deepmerge: "npm:4.3.1"
     fast-glob: "npm:3.3.2"
     string-env-interpolation: "npm:1.0.1"
-  checksum: 10c0/c3ff83182e319b1040eedac331e906a451279938be00096d780741bdc17e41a853dd908079ec693f3cc8af6f58ffdc3d6ba76deaedf8699af4bbb80a686dc0da
+  checksum: 10c0/dcd686044db7c809068910a97eefceefd777ea63f91612745333f3c5158256a574b0e1c028f9bce8d4c031467db79f30392de21a979646c6f2329302400eacec
   languageName: node
   linkType: hard
 
-"@redwoodjs/router@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/router@npm:7.6.2"
+"@redwoodjs/router@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/router@npm:7.6.3"
   dependencies:
     "@babel/runtime-corejs3": "npm:7.24.5"
-    "@redwoodjs/auth": "npm:7.6.2"
+    "@redwoodjs/auth": "npm:7.6.3"
     core-js: "npm:3.37.1"
   peerDependencies:
     react: 18.2.0
     react-dom: 18.2.0
-  checksum: 10c0/ba487f7dadff5bab6d58586643f24501b30254504a2fe7be79f8b9befc2e89dc1cf6cf83559c237bb62fd9da559a43fd61f0cf0c6bc267507f0e352f88503197
+  checksum: 10c0/6697a055542d34c88b33c48750d3d85547069e594ac90eca214129230a6cc05f4f38453d139bde014c8e07c5770c51770dae397084150d227cc4efbb847aee20
   languageName: node
   linkType: hard
 
-"@redwoodjs/structure@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/structure@npm:7.6.2"
+"@redwoodjs/structure@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/structure@npm:7.6.3"
   dependencies:
     "@babel/runtime-corejs3": "npm:7.24.5"
     "@iarna/toml": "npm:2.2.5"
     "@prisma/internals": "npm:5.14.0"
-    "@redwoodjs/project-config": "npm:7.6.2"
+    "@redwoodjs/project-config": "npm:7.6.3"
     "@types/line-column": "npm:1.0.2"
     camelcase: "npm:6.3.0"
     core-js: "npm:3.37.1"
@@ -5498,38 +5489,38 @@ __metadata:
     vscode-languageserver-textdocument: "npm:1.0.11"
     vscode-languageserver-types: "npm:3.17.5"
     yargs-parser: "npm:21.1.1"
-  checksum: 10c0/b87f9a941a64a8c9bb4044a06b392f6df182e2818c990d010c843df4c62174707a39cd3374bd62bbb4efe76b8123ed12d9d9d66bab74629838138b023ba4a783
+  checksum: 10c0/a932657c8f16d4643d91ed6b60622b1f36167ee074e23178fc06bfd2979cc9a708cd2d7ea86ccfcf957744b83ee02c005d88f8ad9da1ec7af749389e8192c9ef
   languageName: node
   linkType: hard
 
-"@redwoodjs/telemetry@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/telemetry@npm:7.6.2"
+"@redwoodjs/telemetry@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/telemetry@npm:7.6.3"
   dependencies:
-    "@redwoodjs/project-config": "npm:7.6.2"
-    "@redwoodjs/structure": "npm:7.6.2"
+    "@redwoodjs/project-config": "npm:7.6.3"
+    "@redwoodjs/structure": "npm:7.6.3"
     "@whatwg-node/fetch": "npm:0.9.17"
     ci-info: "npm:4.0.0"
     envinfo: "npm:7.13.0"
     systeminformation: "npm:5.22.9"
     uuid: "npm:9.0.1"
     yargs: "npm:17.7.2"
-  checksum: 10c0/5d55ccdcac470c7dc1599692d382affc7440277717d29c3c91c75f4e0f7535f0080d6ebe1823960a09fb8df9fce09e7ce1947bd95eb2db124dbe2c08500a3af5
+  checksum: 10c0/85f57621f2f812aa7877edc72a0d1fbdc6ae55678eb9b16aaec997d1143ecf04bda9490637eb4eb7fdf4ac60ae1f04368d18b4a76cbb1ad2271c018d6ed4105d
   languageName: node
   linkType: hard
 
-"@redwoodjs/testing@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/testing@npm:7.6.2"
+"@redwoodjs/testing@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/testing@npm:7.6.3"
   dependencies:
     "@babel/runtime-corejs3": "npm:7.24.5"
-    "@redwoodjs/auth": "npm:7.6.2"
-    "@redwoodjs/babel-config": "npm:7.6.2"
-    "@redwoodjs/context": "npm:7.6.2"
-    "@redwoodjs/graphql-server": "npm:7.6.2"
-    "@redwoodjs/project-config": "npm:7.6.2"
-    "@redwoodjs/router": "npm:7.6.2"
-    "@redwoodjs/web": "npm:7.6.2"
+    "@redwoodjs/auth": "npm:7.6.3"
+    "@redwoodjs/babel-config": "npm:7.6.3"
+    "@redwoodjs/context": "npm:7.6.3"
+    "@redwoodjs/graphql-server": "npm:7.6.3"
+    "@redwoodjs/project-config": "npm:7.6.3"
+    "@redwoodjs/router": "npm:7.6.3"
+    "@redwoodjs/web": "npm:7.6.3"
     "@testing-library/jest-dom": "npm:6.4.5"
     "@testing-library/react": "npm:14.3.1"
     "@testing-library/user-event": "npm:14.5.2"
@@ -5548,17 +5539,17 @@ __metadata:
     msw: "npm:1.3.3"
     ts-toolbelt: "npm:9.6.0"
     whatwg-fetch: "npm:3.6.20"
-  checksum: 10c0/0b14a331c2e3384e888776cbcde3487d2392baf9287049901c134431c628c930751c2e8a35bc07b6fbb8ccd367253f30129d4e0ce55f0ba09918c9dd2493fdae
+  checksum: 10c0/d457fc56537ee34b86ad2bb35a0464fe68f5fa4359d98132f9345e025c6fe82e5e19e750469127f2e4487c5cbb77df877ac480769477a2e06556081c07f03ce5
   languageName: node
   linkType: hard
 
-"@redwoodjs/vite@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/vite@npm:7.6.2"
+"@redwoodjs/vite@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/vite@npm:7.6.3"
   dependencies:
-    "@redwoodjs/babel-config": "npm:7.6.2"
-    "@redwoodjs/internal": "npm:7.6.2"
-    "@redwoodjs/project-config": "npm:7.6.2"
+    "@redwoodjs/babel-config": "npm:7.6.3"
+    "@redwoodjs/internal": "npm:7.6.3"
+    "@redwoodjs/project-config": "npm:7.6.3"
     "@vitejs/plugin-react": "npm:4.2.1"
     buffer: "npm:6.0.3"
     core-js: "npm:3.37.1"
@@ -5568,16 +5559,16 @@ __metadata:
     rw-vite-build: bins/rw-vite-build.mjs
     rw-vite-dev: bins/rw-vite-dev.mjs
     vite: bins/vite.mjs
-  checksum: 10c0/0b5b92e83a6ab932aab9c67e40d8d55b8527217596ea6906a4b7cd3432eaaf73e7c9e998033dc3ace2e2cad95fa199ab483b8a44499a3d69258a04e085940be7
+  checksum: 10c0/c5a8bcbdcf583f6ab457396798e3e932163ef8aae24a15f38c41ee012c51df939c9c825eae0aa9f71072cad7cc387b97a185a866808cb903aa062618e678cb30
   languageName: node
   linkType: hard
 
-"@redwoodjs/web-server@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/web-server@npm:7.6.2"
+"@redwoodjs/web-server@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/web-server@npm:7.6.3"
   dependencies:
-    "@redwoodjs/fastify-web": "npm:7.6.2"
-    "@redwoodjs/project-config": "npm:7.6.2"
+    "@redwoodjs/fastify-web": "npm:7.6.3"
+    "@redwoodjs/project-config": "npm:7.6.3"
     chalk: "npm:4.1.2"
     dotenv-defaults: "npm:5.0.2"
     fastify: "npm:4.27.0"
@@ -5585,17 +5576,17 @@ __metadata:
     yargs: "npm:17.7.2"
   bin:
     rw-web-server: dist/bin.js
-  checksum: 10c0/f1b366abd0a301b0ebbf0fa03ef9d3735988c00eee259756ff5bccb1774102ee9cc8e52b532f4b3ae8a42e2e7021653adfe191ca6809e95de2ffa39405239a99
+  checksum: 10c0/c11000b8c59e9aea9fbc11fd12f03dd3ff5bcfa99b49e7ba587947b8a9c4ef5b090bcb528e056aca8b7a8f40d95974095945fc60927b47e94fc47ae3e833d6b2
   languageName: node
   linkType: hard
 
-"@redwoodjs/web@npm:7.6.2":
-  version: 7.6.2
-  resolution: "@redwoodjs/web@npm:7.6.2"
+"@redwoodjs/web@npm:7.6.3":
+  version: 7.6.3
+  resolution: "@redwoodjs/web@npm:7.6.3"
   dependencies:
     "@apollo/client": "npm:3.9.9"
     "@babel/runtime-corejs3": "npm:7.24.5"
-    "@redwoodjs/auth": "npm:7.6.2"
+    "@redwoodjs/auth": "npm:7.6.3"
     core-js: "npm:3.37.1"
     graphql: "npm:16.8.1"
     graphql-sse: "npm:2.5.3"
@@ -5616,7 +5607,7 @@ __metadata:
     storybook: dist/bins/storybook.js
     tsc: dist/bins/tsc.js
     webpack: dist/bins/webpack.js
-  checksum: 10c0/47d3c86171c547759b6a0850ffe0c013b211275768b6baed39f2bf637fbedefa7418a9276be7c8aff4d8f979c5847dfeaeab78cd3d35b66a12d3bf6276c16b21
+  checksum: 10c0/57858eaebc4762ae55dac14a707ffd81c473eb27ec19dc117f324a82413b9b7d3e15786b1293a81120c93a20d3c8bf1a39b4a5aa17a372cc31b901b57445e66e
   languageName: node
   linkType: hard
 
@@ -7526,8 +7517,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api@workspace:api"
   dependencies:
-    "@redwoodjs/api": "npm:7.6.2"
-    "@redwoodjs/graphql-server": "npm:7.6.2"
+    "@redwoodjs/api": "npm:7.6.3"
+    "@redwoodjs/graphql-server": "npm:7.6.3"
   languageName: unknown
   linkType: soft
 
@@ -8817,14 +8808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001587":
-  version: 1.0.30001618
-  resolution: "caniuse-lite@npm:1.0.30001618"
-  checksum: 10c0/2e33e5e854fb6365566e2ff5ba866c877cd08ca278a2c06b9bc3346a884fc1336a0674c2a0003e7ee7a1a64e90f167ec4ad08ea14d12da5926017c92c99f82a5
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001599":
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001587, caniuse-lite@npm:^1.0.30001599":
   version: 1.0.30001621
   resolution: "caniuse-lite@npm:1.0.30001621"
   checksum: 10c0/c7e7fb021ca32b26394ddf0d62faa8a7919c2e50f8a0dcc51f02a96b7b46fff69a81d6b7ead711367fcaf9dfbc6c795320553b6f84dcb393806a10efeb756ce7
@@ -19255,8 +19239,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@redwoodjs/core": "npm:7.6.2"
-    "@redwoodjs/project-config": "npm:7.6.2"
+    "@redwoodjs/core": "npm:7.6.3"
+    "@redwoodjs/project-config": "npm:7.6.3"
     prettier-plugin-tailwindcss: "npm:0.4.1"
   languageName: unknown
   linkType: soft
@@ -21894,10 +21878,10 @@ __metadata:
     "@radix-ui/react-dropdown-menu": "npm:^2.0.6"
     "@radix-ui/react-navigation-menu": "npm:^1.1.4"
     "@radix-ui/react-slot": "npm:^1.0.2"
-    "@redwoodjs/forms": "npm:7.6.2"
-    "@redwoodjs/router": "npm:7.6.2"
-    "@redwoodjs/vite": "npm:7.6.2"
-    "@redwoodjs/web": "npm:7.6.2"
+    "@redwoodjs/forms": "npm:7.6.3"
+    "@redwoodjs/router": "npm:7.6.3"
+    "@redwoodjs/vite": "npm:7.6.3"
+    "@redwoodjs/web": "npm:7.6.3"
     "@tremor/react": "npm:^3.17.2"
     "@types/react": "npm:^18.2.55"
     "@types/react-dom": "npm:^18.2.19"


### PR DESCRIPTION
This PR updates Redwood JS to 7.6.3