### PR TITLE
Resizing the stacked bar graph for datasets over time

### DIFF
--- a/web/src/components/ItemsOverTimeCell/ItemsOverTimeCell.tsx
+++ b/web/src/components/ItemsOverTimeCell/ItemsOverTimeCell.tsx
@@ -3,6 +3,7 @@ import {
   BarChart,
   CartesianGrid,
   Legend,
+  ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
@@ -94,22 +95,24 @@ export const Success = ({
       <CardHeader>
         <CardTitle>Datasets Over Time</CardTitle>
       </CardHeader>
-      <CardContent className="flex justify-center">
-        <BarChart width={400} height={500} data={datesWithLicenses}>
-          <Tooltip />
-          <CartesianGrid vertical={false} strokeDasharray={5} />
-          <YAxis />
-          <XAxis dataKey={'date'} />
-          {licenses.map((license) => (
-            <Bar
-              key={license}
-              dataKey={license}
-              stackId={'a'}
-              fill={LICENSES_PALLETTE[license]}
-            />
-          ))}
-          <Legend />
-        </BarChart>
+      <CardContent>
+        <ResponsiveContainer width={'100%'} height={500}>
+          <BarChart data={datesWithLicenses}>
+            <Tooltip />
+            <CartesianGrid vertical={false} strokeDasharray={5} />
+            <YAxis />
+            <XAxis dataKey={'date'} />
+            {licenses.map((license) => (
+              <Bar
+                key={license}
+                dataKey={license}
+                stackId={'a'}
+                fill={LICENSES_PALLETTE[license]}
+              />
+            ))}
+            <Legend />
+          </BarChart>
+        </ResponsiveContainer>
       </CardContent>
     </Card>
   )

--- a/web/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/web/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -18,7 +18,7 @@ const DefaultLayout = ({ children }: DefaultLayoutProps) => {
         <h1 className="mx-1 font-bold">
           <Link to={routes.home()}>4TU.RD - TU/e Dashboard</Link>
         </h1>
-        <NavigationMenu>
+        <NavigationMenu className="ml-4">
           <NavigationMenuList>
             <Link to={routes.home()}>
               <NavigationMenuItem className={navigationMenuTriggerStyle()}>


### PR DESCRIPTION
This PR resizes the stacked bar graph for showing different licenses issued for datasets over time.

This PR also includes a tiny margin fix for the layout (more space between the title and the other navbar buttons).

